### PR TITLE
Disable telemetry when validating config

### DIFF
--- a/pre_commit_hooks/circleci-validate.sh
+++ b/pre_commit_hooks/circleci-validate.sh
@@ -12,4 +12,4 @@ if ! command -v circleci &>/dev/null; then
   exit 1
 fi
 
-circleci config validate
+CIRCLECI_CLI_TELEMETRY_OPTOUT=true circleci config validate


### PR DESCRIPTION
This PR disables telemetry when validating the config. Without this, the first time precommit runs the hook in an interactive terminal, it will hang indefinitely. It is waiting for the user to make a choice on whether to send telemetry to CircleCI, but that log is not shown in the terminal